### PR TITLE
feat: block in help popover and logic

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -52,6 +52,7 @@
                :daily-notes/items   []
                :selected/items      []
                :theme/dark          false
+               :show-help?          true
                :graph-conf          default-graph-conf})
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -29,6 +29,12 @@
     db/rfdb))
 
 
+(reg-event-db
+ :toggle-help
+ (fn [db _]
+   (update db :show-help? not)))
+
+
 (reg-event-fx
   :db/update-filepath
   (fn [{:keys [db]} [_ filepath]]

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -8,6 +8,7 @@
     [athens.views.athena :refer [athena-component]]
     [athens.views.devtool :refer [devtool-component]]
     [athens.views.filesystem :as filesystem]
+    [athens.views.help :as help]
     [athens.views.left-sidebar :as left-sidebar]
     [athens.views.pages.core :as pages]
     [athens.views.right-sidebar :as right-sidebar]
@@ -90,5 +91,6 @@
                  [app-toolbar/app-toolbar]
                  [left-sidebar/left-sidebar]
                  [pages/view]
+                 [help/help]
                  [right-sidebar/right-sidebar]
                  [devtool-component]]])])))

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -27,7 +27,7 @@
     [athens.views.filesystem :as filesystem]
     [athens.views.presence :as presence]
     [athens.ws-client :as ws]
-    [re-frame.core :refer [subscribe dispatch]]
+    [re-frame.core :refer [subscribe dispatch reg-sub]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
 
@@ -85,6 +85,14 @@
                     {:opacity "0"}]
                    [:to
                     {:opacity "1"}])
+
+
+;; subscriptions
+
+(reg-sub
+ :show-help?
+ (fn [db _]
+   (:show-help? db)))
 
 
 ;;; Components
@@ -147,13 +155,12 @@
          :on-close close-modal}]])))
 
 
-
-
 (defn app-toolbar
   []
   (let [left-open?        (subscribe [:left-sidebar/open])
         right-open?       (subscribe [:right-sidebar/open])
         route-name        (subscribe [:current-route/name])
+        show-help?        (subscribe [:show-help?])
         electron?         (util/electron?)
         theme-dark        (subscribe [:theme/dark])
         remote-graph-conf (subscribe [:db/remote-graph-conf])
@@ -242,7 +249,9 @@
              [:> LibraryBooks]]
             [separator]
             ;; obnoxious line separator
-            [button {:on-click #(js/alert "help popup") :title "Help Popup"}
+            [button {:on-click #(dispatch [:toggle-help])
+                     :active @show-help?
+                     :title "Help Popup"}
              [:> HelpOutline]]
             ;; obnoxious line separator
             [separator]]

--- a/src/cljs/athens/views/filesystem.cljs
+++ b/src/cljs/athens/views/filesystem.cljs
@@ -258,7 +258,7 @@
         close-modal       (fn []
                             (when-not @loading
                               (dispatch [:modal/toggle])))
-        el (.. js/document (querySelector "#app"))
+        el (.. js/document (querySelector "body"))
         remote-graph-conf (subscribe [:db/remote-graph-conf])
         db-filepath       (subscribe [:db/filepath])
         state             (r/atom {:input     ""

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -1,0 +1,40 @@
+(ns athens.views.help
+  (:require
+   [athens.style :refer [color ZINDICES DEPTH-SHADOWS]]
+   [re-frame.core :refer [reg-sub subscribe]]
+   [reagent.core :as r]
+   [stylefy.core :refer [use-style]]))
+
+;; styles
+
+(def popup-style
+  {:position "absolute"
+   :background (color :background-color)
+   :border-radius "1rem"
+   :box-shadow (:64 DEPTH-SHADOWS)
+   :z-index (:zindex-modal ZINDICES)
+   :bottom "10px"
+   :right "10px"})
+
+
+;; subscriptions
+
+(reg-sub
+ :show-help?
+ (fn [db _]
+   (:show-help? db)))
+
+;; return
+
+(defn help
+  []
+  (let [show-help? (subscribe [:show-help?])
+        el (.. js/document (querySelector "body"))]
+    (fn []
+      (if @show-help?
+
+        (js/ReactDOM.createPortal
+         (r/as-element [:div (use-style popup-style)
+                        [:h1 "Help!"]])
+         el)
+        [:<>]))))


### PR DESCRIPTION
- adds `help` file to top-level content
- adds `show-help?` db item to switch help on/off
- adds event to toggle state of `show-help?`
- adds re-frame subscription to `show-help?` status
- shows Help popup above content when `@show-help?` is true